### PR TITLE
[CMB-18181] | Fix `Package.swift` included in sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
 # XMPPFramework Changelog
+
+## [0.1.1]
+### Fixed
+  - Resolved an issue with `Package.swift` being included in sources, which caused issues in Tuist-based projects. [#2](https://github.com/YAtechnologies/XMPPFramework/pull/2)
+
 ## 0.1.0
   - Stable version from master branch 

--- a/Package.swift
+++ b/Package.swift
@@ -36,6 +36,7 @@ let package = Package(
             ],
             path: ".",
             exclude: [
+                "Package.swift",
                 "Swift",
                 "Xcode",
                 "README.md",


### PR DESCRIPTION
The main target of the package uses `.` (root folder) as sources folder, this makes `Package.swift` part of the source files, which wasn't causing issues when used through SPM (perhaps it excludes it automatically under the hood), but when imported through `Tuist` it caused a compile time error as `Package.swift` should be excluded from sources.

![Screenshot 2024-09-25 at 15 38 13](https://github.com/user-attachments/assets/5c4f2d73-c222-4241-b142-8c14a8dd23b1)

https://yassir.atlassian.net/browse/CMB-18181